### PR TITLE
BASEFEE + EIP-7516: BLOBBASEFEE

### DIFF
--- a/EvmYul/EVM/Instr.lean
+++ b/EvmYul/EVM/Instr.lean
@@ -36,7 +36,7 @@ def serializeCompBitInstr : CBLOp .EVM → UInt8
   | .SHR => 28
   | .SAR => 29
 
-def serializeKeccakInstr : KOp .EVM → UInt8 
+def serializeKeccakInstr : KOp .EVM → UInt8
   | .KECCAK256 => 32
 
 def serializeEnvInstr : EOp .EVM → UInt8
@@ -68,6 +68,7 @@ def serializeBlockInstr : BOp .EVM → UInt8
   | .CHAINID => 70
   | .SELFBALANCE => 71
   | .BASEFEE => 72
+  | .BLOBBASEFEE => 0x4a
 
 def serializeStackMemFlowInstr : SMSFOp .EVM → UInt8
   | .POP => 80
@@ -240,6 +241,7 @@ def serializeInstr : Operation .EVM → UInt8
     | .CHAINID => some 0
     | .SELFBALANCE  => some 0
     | .BASEFEE => some 0
+    | .BLOBBASEFEE => some 0
     | .POP => some 1
     | .MLOAD => some 2
     | .MSTORE => some 2
@@ -355,6 +357,7 @@ def serializeInstr : Operation .EVM → UInt8
     | .CHAINID => some 1
     | .SELFBALANCE => some 1
     | .BASEFEE => some 1
+    | .BLOBBASEFEE => some 1
     | .POP => some 0
     | .MLOAD => some 1
     | .MSTORE => some 0
@@ -438,7 +441,7 @@ def parseInstr : UInt8 → Option (Operation .EVM)
   | 26 => some .BYTE
   | 27 => some .SHL
   | 28 => some .SHR
-  | 29 => some .SAR 
+  | 29 => some .SAR
   | 32 => some .KECCAK256
   | 48 => some .ADDRESS
   | 49 => some .BALANCE
@@ -465,6 +468,7 @@ def parseInstr : UInt8 → Option (Operation .EVM)
   | 70 => some .CHAINID
   | 71 => some .SELFBALANCE
   | 72 => some .BASEFEE
+  | 74 => some .BASEFEE
   | 80 => some .POP
   | 81 => some .MLOAD
   | 82 => some .MSTORE

--- a/EvmYul/Operations.lean
+++ b/EvmYul/Operations.lean
@@ -303,7 +303,17 @@ inductive BOp : OperationType → Type where
     δ: 0 ; α: 1
   -/
   | protected SELFBALANCE : BOp τ
+  /--
+    BASEFEE: get the current block’s base fee
+    δ: 0 ; α: 1
+  -/
   | protected BASEFEE : BOp τ
+  /--
+    BLOBBASEFEE: get the value of the blob base-fee of the current block
+    δ: 0 ; α: 1
+  -/
+  | protected BLOBBASEFEE : BOp τ
+
   deriving DecidableEq, Repr
 
 /--
@@ -616,6 +626,7 @@ abbrev GASLIMIT    {τ : OperationType} : Operation τ := .Block .GASLIMIT
 abbrev CHAINID     {τ : OperationType} : Operation τ := .Block .CHAINID
 abbrev SELFBALANCE {τ : OperationType} : Operation τ := .Block .SELFBALANCE
 abbrev BASEFEE     {τ : OperationType} : Operation τ := .Block .BASEFEE
+abbrev BLOBBASEFEE {τ : OperationType} : Operation τ := .Block .BLOBBASEFEE
 
 abbrev POP     {τ : OperationType} : Operation τ    := .StackMemFlow .POP
 abbrev MLOAD   {τ : OperationType} : Operation τ    := .StackMemFlow .MLOAD

--- a/EvmYul/Semantics.lean
+++ b/EvmYul/Semantics.lean
@@ -287,6 +287,8 @@ def step {τ : OperationType} (op : Operation τ) : Transformer τ :=
     | τ, .GASLIMIT => dispatchStateOp τ EvmYul.State.gasLimit
     | τ, .CHAINID => dispatchStateOp τ EvmYul.State.chainId
     | τ, .SELFBALANCE => dispatchStateOp τ EvmYul.State.selfbalance
+    | τ, .BASEFEE => dispatchExecutionEnvOp τ (.ofNat ∘ BlockHeader.baseFeePerGas ∘ ExecutionEnv.header)
+    | τ, .BLOBBASEFEE => dispatchExecutionEnvOp τ (.ofNat ∘ BlockHeader.blobBaseFeePerGas ∘ ExecutionEnv.header)
 
     | .EVM, .POP =>
       λ evmState ↦

--- a/EvmYul/State/BlockHeader.lean
+++ b/EvmYul/State/BlockHeader.lean
@@ -22,7 +22,8 @@ namespace EvmYul
 `minHash`       `m`
 `chainId`       `n` TODO ????
 `nonce`         `n` [deprecated]
-`baseFeePerGas` `f` 
+`baseFeePerGas` `f`
+`blobBaseFeePerGas` (EIP-7516)
 -/
 structure BlockHeader where
   parentHash    : UInt256
@@ -41,8 +42,9 @@ structure BlockHeader where
   minHash       : UInt256
   chainId       : UInt256 -- TODO(Why is this here?)
   nonce         : UInt64
-  -- prevRandao -- TODO 
+  -- prevRandao -- TODO
   baseFeePerGas : ℕ
+  blobBaseFeePerGas : ℕ
 deriving DecidableEq, Inhabited
 
 attribute [deprecated] BlockHeader.difficulty


### PR DESCRIPTION
Implements #6 
The EVM semmantics for BASEFEE and BLOBBASEFEE is only fetching the corresponding values from the execution environement. Their actual computing would depend on how much gas was used in the previous blocks.