### PR TITLE
Fix extracting bytes for address

### DIFF
--- a/EvmYul/EVM/Semantics.lean
+++ b/EvmYul/EVM/Semantics.lean
@@ -412,7 +412,8 @@ def Lambda
   let n : UInt256 := (σ.lookup s |>.option 0 Account.nonce) - 1
   let lₐ ← L_A s n ζ i
   let a : Address :=
-    (KEC lₐ).extract 96 265 |>.data.toList.reverse |> fromBytes' |> Fin.ofNat
+    (KEC lₐ).extract 12 32 /- 160 bits = 20 bytes -/
+      |>.data.data |> fromBytesBigEndian |> Fin.ofNat
   -- A*
   let AStar := A.addAccessedAccount a
   -- σ*

--- a/EvmYul/Semantics.lean
+++ b/EvmYul/Semantics.lean
@@ -338,7 +338,8 @@ def step {τ : OperationType} (op : Operation τ) : Transformer τ :=
               | none => .error .NotEncodableRLP
               | some L_A =>
                 let addr : Address :=
-                  (KEC L_A).extract 96 265 |>.data.data |> fromBytesBigEndian |> Fin.ofNat
+                  (KEC L_A).extract 12 32 /- 160 bits = 20 bytes -/
+                    |>.data.data |> fromBytesBigEndian |> Fin.ofNat
                 let code : ByteArray := yulState.toMachineState.lookupMemoryRange poz len
                 -- σ*
                 let accountMapStar :=


### PR DESCRIPTION
The Yellow Paper uses the notation 𝓑₉₆..₂₅₅ for the extraction of the rightmost 160 bits of a 256 bits sequence, which is equivalent to extracting the rightmost 20 bytes of a 32 byte array.