### PR TITLE
Test interpreting: prevRandao and accessList

### DIFF
--- a/Conform/Main.lean
+++ b/Conform/Main.lean
@@ -383,9 +383,9 @@ GeneralStateTests:
 
   VMTests                               9m16
     Total tests: 571
-    The post was NOT equal to the resulting state: 31
-    Succeeded: 540
-    Success rate of: 94.570928
+    The post was NOT equal to the resulting state: 30
+    Succeeded: 541
+    Success rate of: 94.746060
 -/
 /-
 InvalidBlocks 2m56

--- a/Conform/Main.lean
+++ b/Conform/Main.lean
@@ -45,11 +45,11 @@ GeneralStateTests:
     Succeeded: 122
     Success rate of: 65.240642
 
-  Pyspecs                               17m54
+  Pyspecs                               22m35
     Total tests: 2150
-    The post was NOT equal to the resulting state: 1779
-    Succeeded: 371
-    Success rate of: 17.255814
+    The post was NOT equal to the resulting state: 1695
+    Succeeded: 455
+    Success rate of: 21.162791
 
   Shanghai                              0m42
     Total tests: 27

--- a/Conform/Main.lean
+++ b/Conform/Main.lean
@@ -40,10 +40,10 @@ def log (testFile : System.FilePath) (testName : String) (result : TestResult) :
 /-
 GeneralStateTests:
   Cancun                                2m59
-    Total tests: 189
-    The post was NOT equal to the resulting state: 73
-    Succeeded: 116
-    Success rate of: 61.375661
+    Total tests: 187
+    The post was NOT equal to the resulting state: 65
+    Succeeded: 122
+    Success rate of: 65.240642
 
   Pyspecs                               17m54
     Total tests: 2150
@@ -141,11 +141,11 @@ GeneralStateTests:
     Succeeded: 4
     Success rate of: 17.391304
 
-  stEIP1559                             17m16
+  stEIP1559                             26m52
     Total tests: 1845
-    The post was NOT equal to the resulting state: 926
-    Succeeded: 919
-    Success rate of: 49.810298
+    The post was NOT equal to the resulting state: 632
+    Succeeded: 1213
+    Success rate of: 65.745257
 
   stEIP158Specific                      0m22
     Total tests: 8
@@ -153,11 +153,11 @@ GeneralStateTests:
     Succeeded: 1
     Success rate of: 12.500000
 
-  stEIP2930                             1m34
+  stEIP2930                             1m50
     Total tests: 140
-    The post was NOT equal to the resulting state: 139
-    Succeeded: 1
-    Success rate of: 0.714286
+    The post was NOT equal to the resulting state: 126
+    Succeeded: 14
+    Success rate of: 10.000000
 
   stEIP3607                             0m27
     Total tests: 12

--- a/Conform/TestParser.lean
+++ b/Conform/TestParser.lean
@@ -160,16 +160,16 @@ instance : FromJson Transaction where
       dbgSender := ← json.getObjValAsD! AccountAddress        "sender"
     }
 
-    match json.getObjVal? "v" with
-      | .ok w => do
-        return .legacy ⟨baseTransaction, ⟨← json.getObjValAsD! UInt256 "gasPrice"⟩, ← FromJson.fromJson? w⟩
+    match json.getObjVal? "accessList" with
       | .error _ => do
+        return .legacy ⟨baseTransaction, ⟨← json.getObjValAsD! UInt256 "gasPrice"⟩, ← json.getObjValAsD! UInt256 "v"⟩
+      | .ok accessList => do
         -- Any other transaction now necessarily has an access list.
         let accessListTransaction : Transaction.WithAccessList :=
           {
             chainId    := let mainnet : Nat := 1; mainnet
-            accessList := ← json.getObjValAsD! _ "accessList" <&> accessListToRBMap
-            yParity    := TODO
+            accessList := ← FromJson.fromJson? accessList <&> accessListToRBMap
+            yParity    := ← json.getObjValAsD! UInt256 "v"
           }
 
         match json.getObjVal? "gasPrice" with

--- a/Conform/TestParser.lean
+++ b/Conform/TestParser.lean
@@ -112,14 +112,7 @@ instance : FromJson BlockHeader where
         nonce         := 0 -- [deprecated] 0.
         baseFeePerGas := ← json.getObjValAsD! _         "baseFeePerGas" <&> UInt256.toNat
         parentBeaconBlockRoot := ← json.getObjValAsD! ByteArray "parentBeaconBlockRoot"
-        /-
-          The tests do not provide `prevRandao` and we do not have a way to compute it.
-          We simply set it to look random.
-        -/
-        prevRandao    :=
-          UInt256.xor
-            (← json.getObjValAsD! UInt256 "parentHash")
-            (← json.getObjValAsD! UInt256 "stateRoot")
+        prevRandao    := ← json.getObjValAsD! UInt256 "mixHash"
         withdrawalsRoot := ← json.getObjValAsD! ByteArray "withdrawalsRoot"
       }
     catch exct => dbg_trace s!"OOOOPSIE: {exct}\n json: {json}"

--- a/Conform/TestRunner.lean
+++ b/Conform/TestRunner.lean
@@ -103,6 +103,8 @@ def VerySlowTests : Array String :=
   , "failed_tx_xcf416c53_Paris_d0g0v0_Cancun"
   , "CALLBlake2f_MaxRounds_d0g0v0_Cancun"
   -- , "CallEcrecover_Overflow_d2g0v0_Cancun" -- PANIC at unsafePerformIO EvmYul.PerformIO
+  , "19_oogUndoesTransientStore_d0g0v0_Cancun"
+  , "20_oogUndoesTransientStoreInCall_d0g0v0_Cancun"
   -- , "callcodecallcall_100_OOGMBefore_d0g0v0_Cancun"
   -- , "callcodecallcodecallcode_111_OOGMBefore_d0g0v0_Cancun"
   -- , "callcallcodecall_010_OOGE_d0g0v0_Cancun"

--- a/EvmYul/State/BlockHeader.lean
+++ b/EvmYul/State/BlockHeader.lean
@@ -51,9 +51,5 @@ deriving DecidableEq, Inhabited, Repr
 
 attribute [deprecated] BlockHeader.difficulty
 attribute [deprecated] BlockHeader.nonce
-/-
-  We return a presudorandom value instead of fetching this field.
--/
-attribute [deprecated] BlockHeader.prevRandao
 
 end EvmYul

--- a/EvmYul/State/ExecutionEnv.lean
+++ b/EvmYul/State/ExecutionEnv.lean
@@ -30,7 +30,7 @@ structure ExecutionEnv :=
   perm      : Bool
   deriving DecidableEq, Inhabited, Repr
 
-protected def prevRandao (e : ExecutionEnv) : UInt256 :=
+def prevRandao (e : ExecutionEnv) : UInt256 :=
   e.header.prevRandao
 
 end EvmYul


### PR DESCRIPTION
- `prevRandao` is "mixHash"
- if we have "accessList" then "v" is `yParity`
- If there is no "accessList" then "v" is `w`
---------
Results:
Overall, not checking the balance and not having reconciled the expected errors yet, there are aproximatively

- 402 tests blacklisted
- 22,288 tests running
- 15,632 tests succeeding

15,632 / (22,288 + 402) = 68%